### PR TITLE
New subscores outputs are supported

### DIFF
--- a/MaxMind.MinFraud.UnitTest/Response/SubscoresTest.cs
+++ b/MaxMind.MinFraud.UnitTest/Response/SubscoresTest.cs
@@ -19,15 +19,18 @@ namespace MaxMind.MinFraud.UnitTest.Response
                 {"country", 0.06},
                 {"country_mismatch", 0.07},
                 {"cvv_result", 0.08},
-                {"email_address", 0.09},
-                {"email_domain", 0.10},
-                {"email_tenure", 0.11},
-                {"ip_tenure", 0.12},
-                {"issuer_id_number", 0.13},
-                {"order_amount", 0.14},
-                {"phone_number", 0.15},
-                {"shipping_address_distance_to_ip_location", 0.16},
-                {"time_of_day", 0.17}
+                {"device", 0.09},
+                {"email_address", 0.10},
+                {"email_domain", 0.11},
+                {"email_local_part", 0.12},
+                {"email_tenure", 0.13},
+                {"ip_tenure", 0.14},
+                {"issuer_id_number", 0.15},
+                {"order_amount", 0.16},
+                {"phone_number", 0.17},
+                {"shipping_address", 0.18},
+                {"shipping_address_distance_to_ip_location", 0.19},
+                {"time_of_day", 0.20}
             }.ToObject<Subscores>()!;
 
             Assert.Equal(0.01, subscores.AvsResult);
@@ -38,17 +41,20 @@ namespace MaxMind.MinFraud.UnitTest.Response
             Assert.Equal(0.06, subscores.Country);
             Assert.Equal(0.07, subscores.CountryMismatch);
             Assert.Equal(0.08, subscores.CvvResult);
-            Assert.Equal(0.09, subscores.EmailAddress);
-            Assert.Equal(0.10, subscores.EmailDomain);
+            Assert.Equal(0.09, subscores.Device);
+            Assert.Equal(0.10, subscores.EmailAddress);
+            Assert.Equal(0.11, subscores.EmailDomain);
+            Assert.Equal(0.12, subscores.EmailLocalPart);
 #pragma warning disable CS0618 // Type or member is obsolete
-            Assert.Equal(0.11, subscores.EmailTenure);
-            Assert.Equal(0.12, subscores.IPTenure);
+            Assert.Equal(0.13, subscores.EmailTenure);
+            Assert.Equal(0.14, subscores.IPTenure);
 #pragma warning restore CS0618 // Type or member is obsolete
-            Assert.Equal(0.13, subscores.IssuerIdNumber);
-            Assert.Equal(0.14, subscores.OrderAmount);
-            Assert.Equal(0.15, subscores.PhoneNumber);
-            Assert.Equal(0.16, subscores.ShippingAddressDistanceToIPLocation);
-            Assert.Equal(0.17, subscores.TimeOfDay);
+            Assert.Equal(0.15, subscores.IssuerIdNumber);
+            Assert.Equal(0.16, subscores.OrderAmount);
+            Assert.Equal(0.17, subscores.PhoneNumber);
+            Assert.Equal(0.18, subscores.ShippingAddress);
+            Assert.Equal(0.19, subscores.ShippingAddressDistanceToIPLocation);
+            Assert.Equal(0.20, subscores.TimeOfDay);
         }
     }
 }

--- a/MaxMind.MinFraud.UnitTest/TestData/factors-response.json
+++ b/MaxMind.MinFraud.UnitTest/TestData/factors-response.json
@@ -157,15 +157,18 @@
     "country": 0.06,
     "country_mismatch": 0.07,
     "cvv_result": 0.08,
-    "email_address": 0.09,
-    "email_domain": 0.10,
-    "email_tenure": 0.11,
-    "ip_tenure": 0.12,
-    "issuer_id_number": 0.13,
-    "order_amount": 0.14,
-    "phone_number": 0.15,
-    "shipping_address_distance_to_ip_location": 0.16,
-    "time_of_day": 0.17
+    "device": 0.09,
+    "email_address": 0.10,
+    "email_domain": 0.11,
+    "email_local_part": 0.12,
+    "email_tenure": 0.13,
+    "ip_tenure": 0.14,
+    "issuer_id_number": 0.15,
+    "order_amount": 0.16,
+    "phone_number": 0.17,
+    "shipping_address": 0.18,
+    "shipping_address_distance_to_ip_location": 0.19,
+    "time_of_day": 0.20
   },
   "warnings": [
     {

--- a/MaxMind.MinFraud/Response/Subscores.cs
+++ b/MaxMind.MinFraud/Response/Subscores.cs
@@ -71,6 +71,13 @@ namespace MaxMind.MinFraud.Response
         public double? CvvResult { get; internal set; }
 
         /// <summary>
+        /// The risk associated with the device. If present, this is a value
+        /// in the range 0.01 to 99.
+        /// </summary>
+        [JsonProperty("device")]
+        public double? Device { get; internal set; }
+
+        /// <summary>
         /// The risk associated with the particular email address. If
         /// present, this is a value in the range 0.01 to 99.
         /// </summary>
@@ -83,6 +90,14 @@ namespace MaxMind.MinFraud.Response
         /// </summary>
         [JsonProperty("email_domain")]
         public double? EmailDomain { get; internal set; }
+
+        /// <summary>
+        /// The risk associated with the email address local part (the part of
+        /// the email address before the @ symbol). If present, this is a
+        /// value in the range 0.01 to 99.
+        /// </summary>
+        [JsonProperty("email_local_part")]
+        public double? EmailLocalPart{ get; internal set; }
 
         /// <summary>
         /// The risk associated with the issuer ID number on the email
@@ -123,6 +138,13 @@ namespace MaxMind.MinFraud.Response
         /// </summary>
         [JsonProperty("phone_number")]
         public double? PhoneNumber { get; internal set; }
+
+        /// <summary>
+        /// The risk associated with the shipping address. If present, this is
+        /// a value in the range 0.01 to 99.
+        /// </summary>
+        [JsonProperty("shipping_address")]
+        public double? ShippingAddress { get; internal set; }
 
         /// <summary>
         /// The risk associated with the distance between the shipping address

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ created for each request. Once you have finished making requests, you
 should dispose of the object to ensure the connections are closed and any
 resources are promptly returned to the system.
 
-### Making a minFraud Score, Insights, or Factors Request ##
+### Making a minFraud Score, Insights, or Factors Request ###
 
 Create a new `Transaction` object. This represents the transaction that you
 are sending to minFraud:
@@ -96,7 +96,7 @@ the request fails, an exception will be thrown.
 
 See the API documentation for more details.
 
-### Reporting a Transaction to MaxMind ##
+### Reporting a Transaction to MaxMind ###
 
 If a transaction was scored incorrectly or you received a chargeback, you may
 report it to MaxMind. To do this, create a new `TransactionReport` object:

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -11,6 +11,10 @@ Release Notes
   * `Paytm`
   * `Razorpay`
   * `Systempay`
+* Added support for new Subscores outputs. These are
+  available as the `Device`, `EmailLocalPart` and `ShippingAddress` properties
+  on `MaxMind.MinFraud.Response.Subscores` on minFraud Factors response
+  objects.
 
 2.6.0 (2020-06-19)
 ------------------


### PR DESCRIPTION
Add support for `Device`, `LocalEmailPart` and `ShippingAddress` subscores for Factors requests.