### PR TITLE
Custom rule label, minFraud "test" action, and 3DS result added

### DIFF
--- a/MaxMind.MinFraud.UnitTest/Request/CreditCardTest.cs
+++ b/MaxMind.MinFraud.UnitTest/Request/CreditCardTest.cs
@@ -115,10 +115,10 @@ namespace MaxMind.MinFraud.UnitTest.Request
         }
 
         [Fact]
-        public void TestWas3dSecureSuccessful()
+        public void TestWas3DSecureSuccessful()
         {
-            var cc = new CreditCard(was3dSecureSuccessful: true);
-            Assert.True(cc.Was3dSecureSuccessful);
+            var cc = new CreditCard(was3DSecureSuccessful: true);
+            Assert.True(cc.Was3DSecureSuccessful);
         }
     }
 }

--- a/MaxMind.MinFraud.UnitTest/Request/CreditCardTest.cs
+++ b/MaxMind.MinFraud.UnitTest/Request/CreditCardTest.cs
@@ -92,7 +92,6 @@ namespace MaxMind.MinFraud.UnitTest.Request
             Assert.Equal('N', cc.CvvResult);
         }
 
-
         [Theory]
         [InlineData("4485921507912924")]
         [InlineData("432312")]
@@ -113,6 +112,13 @@ namespace MaxMind.MinFraud.UnitTest.Request
         {
             var cc = new CreditCard(token: token);
             Assert.Equal(token, cc.Token);
+        }
+
+        [Fact]
+        public void TestWas3dSecureSuccessful()
+        {
+            var cc = new CreditCard(was3dSecureSuccessful: true);
+            Assert.True(cc.Was3dSecureSuccessful);
         }
     }
 }

--- a/MaxMind.MinFraud.UnitTest/Request/TestHelper.cs
+++ b/MaxMind.MinFraud.UnitTest/Request/TestHelper.cs
@@ -125,7 +125,8 @@ namespace MaxMind.MinFraud.UnitTest.Request
                     avsResult: 'Y',
                     cvvResult: 'N',
                     last4Digits: "7643",
-                    token: "123456abc1234"
+                    token: "123456abc1234",
+                    was3dSecureSuccessful: false
                 ),
                 customInputs: new CustomInputs.Builder
                 {
@@ -238,7 +239,8 @@ namespace MaxMind.MinFraud.UnitTest.Request
                     AvsResult = 'Y',
                     CvvResult = 'N',
                     Last4Digits = "7643",
-                    Token = "123456abc1234"
+                    Token = "123456abc1234",
+                    Was3dSecureSuccessful = false,
                 },
                 CustomInputs = new CustomInputs.Builder
                 {

--- a/MaxMind.MinFraud.UnitTest/Request/TestHelper.cs
+++ b/MaxMind.MinFraud.UnitTest/Request/TestHelper.cs
@@ -126,7 +126,7 @@ namespace MaxMind.MinFraud.UnitTest.Request
                     cvvResult: 'N',
                     last4Digits: "7643",
                     token: "123456abc1234",
-                    was3dSecureSuccessful: false
+                    was3DSecureSuccessful: false
                 ),
                 customInputs: new CustomInputs.Builder
                 {
@@ -240,7 +240,7 @@ namespace MaxMind.MinFraud.UnitTest.Request
                     CvvResult = 'N',
                     Last4Digits = "7643",
                     Token = "123456abc1234",
-                    Was3dSecureSuccessful = false,
+                    Was3DSecureSuccessful = false,
                 },
                 CustomInputs = new CustomInputs.Builder
                 {

--- a/MaxMind.MinFraud.UnitTest/Response/DispositionTest.cs
+++ b/MaxMind.MinFraud.UnitTest/Response/DispositionTest.cs
@@ -13,12 +13,14 @@ namespace MaxMind.MinFraud.UnitTest.Response
                 @"
                     {
                         ""action"": ""manual_review"",
-                        ""reason"": ""custom_rule""
+                        ""reason"": ""custom_rule"",
+                        ""rule_label"": ""the rule's label""
                     }
                 ")!;
 
             Assert.Equal("manual_review", disposition.Action);
             Assert.Equal("custom_rule", disposition.Reason);
+            Assert.Equal("the rule's label", disposition.RuleLabel);
         }
     }
 }

--- a/MaxMind.MinFraud.UnitTest/TestData/factors-response.json
+++ b/MaxMind.MinFraud.UnitTest/TestData/factors-response.json
@@ -5,7 +5,8 @@
   "queries_remaining": 1000,
   "disposition": {
     "action": "reject",
-    "reason": "custom_rule"
+    "reason": "custom_rule",
+    "rule_label": "The label"
   },
   "ip_address": {
     "risk": 0.01,

--- a/MaxMind.MinFraud.UnitTest/TestData/full-request.json
+++ b/MaxMind.MinFraud.UnitTest/TestData/full-request.json
@@ -53,7 +53,8 @@
     "bank_phone_number": "123-456-1234",
     "avs_result": "Y",
     "cvv_result": "N",
-    "token": "123456abc1234"
+    "token": "123456abc1234",
+    "was_3d_secure_successful": false
   },
   "custom_inputs": {
     "float_input": 12.1,

--- a/MaxMind.MinFraud.UnitTest/TestData/insights-response.json
+++ b/MaxMind.MinFraud.UnitTest/TestData/insights-response.json
@@ -5,7 +5,8 @@
   "queries_remaining": 1000,
   "disposition": {
     "action": "reject",
-    "reason": "custom_rule"
+    "reason": "custom_rule",
+    "rule_label": "The label"
   },
   "ip_address": {
     "risk": 0.01,

--- a/MaxMind.MinFraud.UnitTest/TestData/score-response.json
+++ b/MaxMind.MinFraud.UnitTest/TestData/score-response.json
@@ -5,7 +5,8 @@
   "queries_remaining": 1000,
   "disposition": {
     "action": "reject",
-    "reason": "custom_rule"
+    "reason": "custom_rule",
+    "rule_label": "The label"
   },
   "ip_address": {
     "risk": 99.0

--- a/MaxMind.MinFraud/Request/CreditCard.cs
+++ b/MaxMind.MinFraud/Request/CreditCard.cs
@@ -73,6 +73,22 @@ namespace MaxMind.MinFraud.Request
         }
 
         /// <summary>
+        /// [Obsolete("Legacy constructor for backwards compatibility")]
+        /// </summary>
+        public CreditCard(
+            string? issuerIdNumber,
+            string? last4Digits,
+            string? bankName,
+            string? bankPhoneCountryCode,
+            string? bankPhoneNumber,
+            char? avsResult,
+            char? cvvResult,
+            string? token
+        ) : this(issuerIdNumber, last4Digits, bankName, bankPhoneCountryCode, bankPhoneNumber, avsResult, cvvResult, token, null)
+        {
+        }
+
+        /// <summary>
         /// The issuer ID number for the credit card. This is the first 6
         /// digits of the credit card number. It identifies the issuing bank.
         /// </summary>

--- a/MaxMind.MinFraud/Request/CreditCard.cs
+++ b/MaxMind.MinFraud/Request/CreditCard.cs
@@ -42,6 +42,8 @@ namespace MaxMind.MinFraud.Request
         ///  as provided by the payment processor.</param>
         /// <param name="token">A token uniquely identifying the card. This
         /// should not be the actual credit card number.</param>
+        /// <param name="was3dSecureSuccessful">Whether or not the 3DS check was
+        /// successful, as provided by the end user.</param>
         public CreditCard(
             string? issuerIdNumber = null,
             string? last4Digits = null,
@@ -50,7 +52,8 @@ namespace MaxMind.MinFraud.Request
             string? bankPhoneNumber = null,
             char? avsResult = null,
             char? cvvResult = null,
-            string? token = null
+            string? token = null,
+            bool? was3dSecureSuccessful = null
         )
         {
             IssuerIdNumber = issuerIdNumber;
@@ -61,6 +64,7 @@ namespace MaxMind.MinFraud.Request
             AvsResult = avsResult;
             CvvResult = cvvResult;
             Token = token;
+            Was3dSecureSuccessful = was3dSecureSuccessful;
         }
 
         /// <summary>
@@ -133,7 +137,6 @@ namespace MaxMind.MinFraud.Request
         [JsonPropertyName("cvv_result")]
         public char? CvvResult { get; init; }
 
-
         /// <summary>
         /// A token uniquely identifying the card. This should not be
         /// the actual credit card number.
@@ -155,13 +158,20 @@ namespace MaxMind.MinFraud.Request
         }
 
         /// <summary>
+        /// Whether or not the 3DS check was successful, as provided by the end
+        /// user.
+        /// </summary>
+        [JsonPropertyName("was_3d_secure_successful")]
+        public bool? Was3dSecureSuccessful { get; init; }
+
+        /// <summary>
         /// Returns a string that represents the current object.
         /// </summary>
         /// <returns>A string that represents the current object.</returns>
         public override string ToString()
         {
             return
-                $"IssuerIdNumber: {IssuerIdNumber}, Last4Digits: {Last4Digits}, BankName: {BankName}, BankPhoneCountryCode: {BankPhoneCountryCode}, BankPhoneNumber: {BankPhoneNumber}, AvsResult: {AvsResult}, CvvResult: {CvvResult}, Token: {Token}";
+                $"IssuerIdNumber: {IssuerIdNumber}, Last4Digits: {Last4Digits}, BankName: {BankName}, BankPhoneCountryCode: {BankPhoneCountryCode}, BankPhoneNumber: {BankPhoneNumber}, AvsResult: {AvsResult}, CvvResult: {CvvResult}, Token: {Token}, Was3dSecureSuccessful: {Was3dSecureSuccessful}";
         }
     }
 }

--- a/MaxMind.MinFraud/Request/CreditCard.cs
+++ b/MaxMind.MinFraud/Request/CreditCard.cs
@@ -42,7 +42,7 @@ namespace MaxMind.MinFraud.Request
         ///  as provided by the payment processor.</param>
         /// <param name="token">A token uniquely identifying the card. This
         /// should not be the actual credit card number.</param>
-        /// <param name="was3dSecureSuccessful">Whether or not the 3D-Secure
+        /// <param name="was3DSecureSuccessful">Whether or not the 3D-Secure
         /// verification (e.g. Safekey, SecureCode, Verified by Visa) was
         /// successful, as provided by the end user. `true` if customer
         /// verification was successful, or `false` if the customer failed
@@ -58,7 +58,7 @@ namespace MaxMind.MinFraud.Request
             char? avsResult = null,
             char? cvvResult = null,
             string? token = null,
-            bool? was3dSecureSuccessful = null
+            bool? was3DSecureSuccessful = null
         )
         {
             IssuerIdNumber = issuerIdNumber;
@@ -69,7 +69,7 @@ namespace MaxMind.MinFraud.Request
             AvsResult = avsResult;
             CvvResult = cvvResult;
             Token = token;
-            Was3dSecureSuccessful = was3dSecureSuccessful;
+            Was3DSecureSuccessful = was3DSecureSuccessful;
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace MaxMind.MinFraud.Request
         /// or failure, do not include this parameter.
         /// </summary>
         [JsonPropertyName("was_3d_secure_successful")]
-        public bool? Was3dSecureSuccessful { get; init; }
+        public bool? Was3DSecureSuccessful { get; init; }
 
         /// <summary>
         /// Returns a string that represents the current object.
@@ -196,7 +196,7 @@ namespace MaxMind.MinFraud.Request
         public override string ToString()
         {
             return
-                $"IssuerIdNumber: {IssuerIdNumber}, Last4Digits: {Last4Digits}, BankName: {BankName}, BankPhoneCountryCode: {BankPhoneCountryCode}, BankPhoneNumber: {BankPhoneNumber}, AvsResult: {AvsResult}, CvvResult: {CvvResult}, Token: {Token}, Was3dSecureSuccessful: {Was3dSecureSuccessful}";
+                $"IssuerIdNumber: {IssuerIdNumber}, Last4Digits: {Last4Digits}, BankName: {BankName}, BankPhoneCountryCode: {BankPhoneCountryCode}, BankPhoneNumber: {BankPhoneNumber}, AvsResult: {AvsResult}, CvvResult: {CvvResult}, Token: {Token}, Was3DSecureSuccessful: {Was3DSecureSuccessful}";
         }
     }
 }

--- a/MaxMind.MinFraud/Request/CreditCard.cs
+++ b/MaxMind.MinFraud/Request/CreditCard.cs
@@ -42,8 +42,13 @@ namespace MaxMind.MinFraud.Request
         ///  as provided by the payment processor.</param>
         /// <param name="token">A token uniquely identifying the card. This
         /// should not be the actual credit card number.</param>
-        /// <param name="was3dSecureSuccessful">Whether or not the 3DS check was
-        /// successful, as provided by the end user.</param>
+        /// <param name="was3dSecureSuccessful">Whether or not the 3D-Secure
+        /// verification (e.g. Safekey, SecureCode, Verified by Visa) was
+        /// successful, as provided by the end user. `true` if customer
+        /// verification was successful, or `false` if the customer failed
+        /// verification. If 3-D Secure verification was not used, was
+        /// unavailable, or resulted in an outcome other than success or
+        /// failure, do not include this parameter.</param>
         public CreditCard(
             string? issuerIdNumber = null,
             string? last4Digits = null,
@@ -158,8 +163,12 @@ namespace MaxMind.MinFraud.Request
         }
 
         /// <summary>
-        /// Whether or not the 3DS check was successful, as provided by the end
-        /// user.
+        /// Whether or not the 3D-Secure verification (e.g. Safekey, SecureCode,
+        /// Verified by Visa) was successful, as provided by the end user.
+        /// `true` if customer verification was successful, or `false` if the
+        /// customer failed verification. If 3-D Secure verification was not
+        /// used, was unavailable, or resulted in an outcome other than success
+        /// or failure, do not include this parameter.
         /// </summary>
         [JsonPropertyName("was_3d_secure_successful")]
         public bool? Was3dSecureSuccessful { get; init; }

--- a/MaxMind.MinFraud/Response/Disposition.cs
+++ b/MaxMind.MinFraud/Response/Disposition.cs
@@ -10,8 +10,8 @@ namespace MaxMind.MinFraud.Response
         /// <summary>
         /// The action to take on the transaction as defined by your custom
         /// rules. The current set of values are "accept", "manual_review",
-        /// and "reject". If you do not have custom rules set up, <c>null</c>
-        /// will be returned.
+        /// "reject" and "test". If you do not have custom rules set up,
+        /// <c>null</c> will be returned.
         /// </summary>
         [JsonPropertyName("action")]
         public string? Action { get; init; }

--- a/MaxMind.MinFraud/Response/Disposition.cs
+++ b/MaxMind.MinFraud/Response/Disposition.cs
@@ -25,11 +25,20 @@ namespace MaxMind.MinFraud.Response
         public string? Reason { get; init; }
 
         /// <summary>
+        /// The label of the custom rule that was triggered. If you do not have
+        /// custom rules set up, the triggered custom rule does not have a
+        /// label, or no custom rule was triggered, <c>null</c> will be
+        /// returned.
+        /// </summary>
+        [JsonPropertyName("rule_label")]
+        public string? RuleLabel { get; init; }
+
+        /// <summary>
         /// Returns a string that represents the current object.
         /// </summary>
         public override string ToString()
         {
-            return $"Action: {Action}, Reason: {Reason}";
+            return $"Action: {Action}, Reason: {Reason}, Rule Label: {RuleLabel}";
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -287,7 +287,8 @@ public class MinFraudExample
                 AvsResult = 'Y',
                 CvvResult = 'N',
                 Last4Digits = "7643",
-                Token = "123456abc1234"
+                Token = "123456abc1234",
+                Was3dSecureSuccessful = true
             },
             CustomInputs = new CustomInputs.Builder
             {

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ public class MinFraudExample
                 CvvResult = 'N',
                 Last4Digits = "7643",
                 Token = "123456abc1234",
-                Was3dSecureSuccessful = true
+                Was3DSecureSuccessful = true
             },
             CustomInputs = new CustomInputs.Builder
             {

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -17,6 +17,13 @@ Release Notes
   Factors. This is the available as the `RiskLabel` property of
   `MaxMind.MinFraud.Response.Disposition`, and is the label of the custom rule
   that was triggered by the transaction.
+* Added support for the `/credit_card/was_3d_secure_successful` input in Score,
+  Insights and Factors. This input should indicate whether or not the outcome
+  of 3-D Secure verification (e.g. Safekey, SecureCode, Verified by Visa) was
+  successful. `true` if customer verification was successful, or `false` if
+  the customer failed verification. If 3-D Secure verification was not used, was
+  unavailable, or resulted in another outcome other than success or failure, do
+  not include this field.
 
 3.1.0 (2021-02-02)
 ------------------

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -13,6 +13,10 @@ Release Notes
   * `Onpay`
   * `Safecharge`
 * Documented the new "test" disposition.
+* Added support for the `/disposition/risk_label` output in Score, Insights and
+  Factors. This is the available as the `RiskLabel` property of
+  `MaxMind.MinFraud.Response.Disposition`, and is the label of the custom rule
+  that was triggered by the transaction.
 
 3.1.0 (2021-02-02)
 ------------------

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -12,6 +12,7 @@ Release Notes
   * `Dlocal`
   * `Onpay`
   * `Safecharge`
+* Documented the new "test" disposition.
 
 3.1.0 (2021-02-02)
 ------------------


### PR DESCRIPTION
* Document the "test" disposition action
* Add support for the `/disposition/rule_label` output.
* Add support for the `/credit_card/was_3d_secure_successful` input.