### PR TITLE
Add support for 8 digit IINs and 2 digit LastDigits

### DIFF
--- a/MaxMind.MinFraud.UnitTest/Request/CreditCardTest.cs
+++ b/MaxMind.MinFraud.UnitTest/Request/CreditCardTest.cs
@@ -9,14 +9,23 @@ namespace MaxMind.MinFraud.UnitTest.Request
         [Fact]
         public void TestIssuerIdNumber()
         {
-            var cc = new CreditCard(issuerIdNumber: "123456");
-            Assert.Equal("123456", cc.IssuerIdNumber);
+            var cc6 = new CreditCard(issuerIdNumber: "123456");
+            Assert.Equal("123456", cc6.IssuerIdNumber);
+
+            var cc8 = new CreditCard(issuerIdNumber: "12345678");
+            Assert.Equal("12345678", cc8.IssuerIdNumber);
+        }
+
+        [Fact]
+        public void TestIssuerIdNumberThatIsInvalidLength()
+        {
+            Assert.Throws<ArgumentException>(() => new CreditCard(issuerIdNumber: "1234567"));
         }
 
         [Fact]
         public void TestIssuerIdNumberThatIsTooLong()
         {
-            Assert.Throws<ArgumentException>(() => new CreditCard(issuerIdNumber: "1234567"));
+            Assert.Throws<ArgumentException>(() => new CreditCard(issuerIdNumber: "123456789"));
         }
 
         [Fact]
@@ -34,26 +43,39 @@ namespace MaxMind.MinFraud.UnitTest.Request
         [Fact]
         public void TestLast4Digits()
         {
-            var cc = new CreditCard(last4Digits: "1234");
-            Assert.Equal("1234", cc.Last4Digits);
+            var cc2 = new CreditCard(last4Digits: "12");
+            Assert.Equal("12", cc2.Last4Digits);
+
+            var cc4 = new CreditCard(last4Digits: "1234");
+            Assert.Equal("1234", cc4.Last4Digits);
         }
 
         [Fact]
-        public void TestLast4DigitsThatIsTooLong()
+        public void TestLastDigits()
         {
-            Assert.Throws<ArgumentException>(() => new CreditCard(last4Digits: "12345"));
+            var cc2 = new CreditCard(lastDigits: "12");
+            Assert.Equal("12", cc2.LastDigits);
+
+            var cc4 = new CreditCard(lastDigits: "1234");
+            Assert.Equal("1234", cc4.LastDigits);
         }
 
         [Fact]
-        public void TestLast4DigitsThatIsTooShort()
+        public void TestLastDigitsThatIsTooLong()
         {
-            Assert.Throws<ArgumentException>(() => new CreditCard(last4Digits: "123"));
+            Assert.Throws<ArgumentException>(() => new CreditCard(lastDigits: "12345"));
         }
 
         [Fact]
-        public void TestLast4DigitsThatHasLetters()
+        public void TestLastDigitsThatIsTooShort()
         {
-            Assert.Throws<ArgumentException>(() => new CreditCard(last4Digits: "123a"));
+            Assert.Throws<ArgumentException>(() => new CreditCard(lastDigits: "1"));
+        }
+
+        [Fact]
+        public void TestLastDigitsThatHasLetters()
+        {
+            Assert.Throws<ArgumentException>(() => new CreditCard(lastDigits: "123a"));
         }
 
         [Fact]
@@ -101,7 +123,7 @@ namespace MaxMind.MinFraud.UnitTest.Request
             "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")]
         public void TestInvalidToken(string token)
         {
-            Assert.Throws<ArgumentException>(() => new CreditCard(last4Digits: token));
+            Assert.Throws<ArgumentException>(() => new CreditCard(token: token));
         }
 
         [Theory]

--- a/MaxMind.MinFraud.UnitTest/Request/CreditCardTest.cs
+++ b/MaxMind.MinFraud.UnitTest/Request/CreditCardTest.cs
@@ -43,11 +43,13 @@ namespace MaxMind.MinFraud.UnitTest.Request
         [Fact]
         public void TestLast4Digits()
         {
+#pragma warning disable 618
             var cc2 = new CreditCard(last4Digits: "12");
             Assert.Equal("12", cc2.Last4Digits);
 
             var cc4 = new CreditCard(last4Digits: "1234");
             Assert.Equal("1234", cc4.Last4Digits);
+#pragma warning restore 618
         }
 
         [Fact]

--- a/MaxMind.MinFraud.UnitTest/Request/TestHelper.cs
+++ b/MaxMind.MinFraud.UnitTest/Request/TestHelper.cs
@@ -124,7 +124,7 @@ namespace MaxMind.MinFraud.UnitTest.Request
                     bankPhoneNumber: "123-456-1234",
                     avsResult: 'Y',
                     cvvResult: 'N',
-                    last4Digits: "7643",
+                    lastDigits: "7643",
                     token: "123456abc1234",
                     was3DSecureSuccessful: false
                 ),
@@ -238,7 +238,7 @@ namespace MaxMind.MinFraud.UnitTest.Request
                     BankPhoneNumber = "123-456-1234",
                     AvsResult = 'Y',
                     CvvResult = 'N',
-                    Last4Digits = "7643",
+                    LastDigits = "7643",
                     Token = "123456abc1234",
                     Was3DSecureSuccessful = false,
                 },

--- a/MaxMind.MinFraud.UnitTest/TestData/full-request.json
+++ b/MaxMind.MinFraud.UnitTest/TestData/full-request.json
@@ -47,7 +47,7 @@
   },
   "credit_card": {
     "issuer_id_number": "411111",
-    "last_4_digits": "7643",
+    "last_digits": "7643",
     "bank_name": "Bank of No Hope",
     "bank_phone_country_code": "1",
     "bank_phone_number": "123-456-1234",

--- a/MaxMind.MinFraud/Request/CreditCard.cs
+++ b/MaxMind.MinFraud/Request/CreditCard.cs
@@ -77,8 +77,9 @@ namespace MaxMind.MinFraud.Request
         }
 
         /// <summary>
-        /// [Obsolete("Legacy constructor for backwards compatibility")]
+        /// Legacy constructor for backwards compatibility.
         /// </summary>
+        [Obsolete("Legacy constructor for backwards compatibility")]
         public CreditCard(
             string? issuerIdNumber,
             string? last4Digits,
@@ -94,8 +95,9 @@ namespace MaxMind.MinFraud.Request
         }
 
         /// <summary>
-        /// [Obsolete("Legacy constructor for backwards compatibility")]
+        /// Legacy constructor for backwards compatibility.
         /// </summary>
+        [Obsolete("Legacy constructor for backwards compatibility")]
         public CreditCard(
             string? issuerIdNumber,
             string? last4Digits,

--- a/MaxMind.MinFraud/Request/CreditCard.cs
+++ b/MaxMind.MinFraud/Request/CreditCard.cs
@@ -10,13 +10,13 @@ namespace MaxMind.MinFraud.Request
     /// </summary>
     public sealed class CreditCard
     {
-        private static readonly Regex IssuerIdNumberRe = new Regex("^[0-9]{6}$", RegexOptions.Compiled);
-        private static readonly Regex Last4Re = new Regex("^[0-9]{4}$", RegexOptions.Compiled);
+        private static readonly Regex IssuerIdNumberRe = new Regex("^[0-9]{6}$|^[0-9]{8}$", RegexOptions.Compiled);
+        private static readonly Regex LastDigitsRe = new Regex("^[0-9]{2}$|^[0-9]{4}$", RegexOptions.Compiled);
 
         private static readonly Regex TokenRe = new Regex("^(?![0-9]{1,19}$)[\\x21-\\x7E]{1,255}$",
             RegexOptions.Compiled);
         private string? _issuerIdNumber;
-        private string? _last4Digits;
+        private string? _lastDigits;
         private string? _token;
 
 
@@ -24,10 +24,10 @@ namespace MaxMind.MinFraud.Request
         /// Constructor.
         /// </summary>
         /// <param name="issuerIdNumber">The issuer ID number for the credit card.
-        /// This is the first 6 digits of the credit card number. It identifies
-        /// the issuing bank.</param>
-        /// <param name="last4Digits">The last four digits of the credit card
-        /// number.</param>
+        /// This is the first six or eight digits of the credit card number. It
+        /// identifies the issuing bank.</param>
+        /// <param name="lastDigits">The last two or four digits of the credit
+        /// card number.</param>
         /// <param name="bankName">The name of the issuing bank as provided by
         /// the end user</param>
         /// <param name="bankPhoneCountryCode">The phone country code for the
@@ -49,20 +49,24 @@ namespace MaxMind.MinFraud.Request
         /// verification. If 3-D Secure verification was not used, was
         /// unavailable, or resulted in an outcome other than success or
         /// failure, do not include this parameter.</param>
+        /// <param name="last4Digits">The last two or four digits of the credit
+        /// card number. last4Digits is obsolete. Use lastDigits instead.
+        /// </param>
         public CreditCard(
             string? issuerIdNumber = null,
-            string? last4Digits = null,
+            string? lastDigits = null,
             string? bankName = null,
             string? bankPhoneCountryCode = null,
             string? bankPhoneNumber = null,
             char? avsResult = null,
             char? cvvResult = null,
             string? token = null,
-            bool? was3DSecureSuccessful = null
+            bool? was3DSecureSuccessful = null,
+            string? last4Digits = null
         )
         {
             IssuerIdNumber = issuerIdNumber;
-            Last4Digits = last4Digits;
+            LastDigits = lastDigits ?? last4Digits;
             BankName = bankName;
             BankPhoneCountryCode = bankPhoneCountryCode;
             BankPhoneNumber = bankPhoneNumber;
@@ -70,6 +74,23 @@ namespace MaxMind.MinFraud.Request
             CvvResult = cvvResult;
             Token = token;
             Was3DSecureSuccessful = was3DSecureSuccessful;
+        }
+
+        /// <summary>
+        /// [Obsolete("Legacy constructor for backwards compatibility")]
+        /// </summary>
+        public CreditCard(
+            string? issuerIdNumber,
+            string? last4Digits,
+            string? bankName,
+            string? bankPhoneCountryCode,
+            string? bankPhoneNumber,
+            char? avsResult,
+            char? cvvResult,
+            string? token,
+            bool? was3DSecureSuccessful
+        ) : this(issuerIdNumber, last4Digits, bankName, bankPhoneCountryCode, bankPhoneNumber, avsResult, cvvResult, token, was3DSecureSuccessful, null)
+        {
         }
 
         /// <summary>
@@ -107,19 +128,37 @@ namespace MaxMind.MinFraud.Request
         }
 
         /// <summary>
-        /// The last four digits of the credit card number.
+        /// The last two or four digits of the credit card number.
         /// </summary>
-        [JsonPropertyName("last_4_digits")]
+        [Obsolete("Last4Digits is obsolete. Use LastDigits instead.")]
+        [JsonIgnore]
         public string? Last4Digits
         {
-            get => _last4Digits;
+            get => _lastDigits;
             init
             {
-                if (value != null && !Last4Re.IsMatch(value))
+                if (value != null && !LastDigitsRe.IsMatch(value))
                 {
-                    throw new ArgumentException($"The last 4 credit card digits {value} is of the wrong format.");
+                    throw new ArgumentException($"The last credit card digits {value} is of the wrong format.");
                 }
-                _last4Digits = value;
+                _lastDigits = value;
+            }
+        }
+
+        /// <summary>
+        /// The last two or four digits of the credit card number.
+        /// </summary>
+        [JsonPropertyName("last_digits")]
+        public string? LastDigits
+        {
+            get => _lastDigits;
+            init
+            {
+                if (value != null && !LastDigitsRe.IsMatch(value))
+                {
+                    throw new ArgumentException($"The last credit card digits {value} is of the wrong format.");
+                }
+                _lastDigits = value;
             }
         }
 
@@ -196,7 +235,7 @@ namespace MaxMind.MinFraud.Request
         public override string ToString()
         {
             return
-                $"IssuerIdNumber: {IssuerIdNumber}, Last4Digits: {Last4Digits}, BankName: {BankName}, BankPhoneCountryCode: {BankPhoneCountryCode}, BankPhoneNumber: {BankPhoneNumber}, AvsResult: {AvsResult}, CvvResult: {CvvResult}, Token: {Token}, Was3DSecureSuccessful: {Was3DSecureSuccessful}";
+                $"IssuerIdNumber: {IssuerIdNumber}, LastDigits: {LastDigits}, BankName: {BankName}, BankPhoneCountryCode: {BankPhoneCountryCode}, BankPhoneNumber: {BankPhoneNumber}, AvsResult: {AvsResult}, CvvResult: {CvvResult}, Token: {Token}, Was3DSecureSuccessful: {Was3DSecureSuccessful}";
         }
     }
 }

--- a/MaxMind.MinFraud/Request/CreditCard.cs
+++ b/MaxMind.MinFraud/Request/CreditCard.cs
@@ -134,14 +134,10 @@ namespace MaxMind.MinFraud.Request
         [JsonIgnore]
         public string? Last4Digits
         {
-            get => _lastDigits;
+            get => LastDigits;
             init
             {
-                if (value != null && !LastDigitsRe.IsMatch(value))
-                {
-                    throw new ArgumentException($"The last credit card digits {value} is of the wrong format.");
-                }
-                _lastDigits = value;
+                LastDigits = value;
             }
         }
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -21,6 +21,22 @@ Release Notes
   * `Payvision`
   * `Trustly`
   * `Windcave`
+* The `last4Digits` constructor parameter and and `Last4Digits` property of
+  `MaxMind.MinFraud.Request.CreditCard` have been deprecated in favor of
+  `lastDigits` / `LastDigits` respectively and will be removed in a future
+  release. `lastDigits` / `LastDigits` also now supports two digit values in
+  addition to the previous four digit values.
+* Eight digit `MaxMind.MinFraud.Request.CreditCard.issuerIdNumber` inputs are
+  now supported in addition to the previously accepted six digit `issuerIdNumber`.
+  In most cases, you should send the last four digits for
+  `MaxMind.MinFraud.Request.CreditCard.lastDigits`. If you send a `issuerIdNumber`
+  that contains an eight digit IIN, and if the credit card brand is not one of the
+  following, you should send the last two digits for `lastDigits`:
+  * `Discover`
+  * `JCB`
+  * `Mastercard`
+  * `UnionPay`
+  * `Visa`
 
 3.2.0 (2021-08-27)
 ------------------


### PR DESCRIPTION
Previously IssuerIdNumber was expected to be 6 digits and
Last4Digits to be 4 digits. This changes the validation to
additionally allow for 8 digit IssuerIdNumbers and 2 digit
Last4Digits.

Additionally Last4Digits has been deprecated in favor of the
more appropriately named LastDigits.