### PR TITLE
Drop .NET 5.0 target

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,10 +26,13 @@ jobs:
     - run: git checkout HEAD^2
       if: ${{ github.event_name == 'pull_request' }}
 
-    - name: Setup .NET 6.0
+    - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.*
+        dotnet-version: |
+          6.0.x
+          7.0.x
+          8.0.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,13 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup .NET 6.0
+      - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.*
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
 
       - name: Build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,21 +17,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup dotnet 2.2
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 2.2
-
-      - name: Setup dotnet 3.1
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 3.1
-
-      - name: Setup .NET 5.0
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 5.0.*
-
       - name: Setup .NET 6.0
         uses: actions/setup-dotnet@v3
         with:

--- a/MaxMind.MinFraud.UnitTest/MaxMind.MinFraud.UnitTest.csproj
+++ b/MaxMind.MinFraud.UnitTest/MaxMind.MinFraud.UnitTest.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <Description>Test project for minFraud API</Description>
     <VersionPrefix>0.6.0</VersionPrefix>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net6.0;net5.0;net472;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net6.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
     <AssemblyName>MaxMind.MinFraud.UnitTest</AssemblyName>
     <PackageId>MaxMind.MinFraud.UnitTest</PackageId>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/MaxMind.MinFraud.UnitTest/MaxMind.MinFraud.UnitTest.csproj
+++ b/MaxMind.MinFraud.UnitTest/MaxMind.MinFraud.UnitTest.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <Description>Test project for minFraud API</Description>
     <VersionPrefix>0.6.0</VersionPrefix>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net6.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0;net7.0;net6.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net8.0;net7.0;net6.0</TargetFrameworks>
     <AssemblyName>MaxMind.MinFraud.UnitTest</AssemblyName>
     <PackageId>MaxMind.MinFraud.UnitTest</PackageId>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/MaxMind.MinFraud.UnitTest/WebServiceClientTest.cs
+++ b/MaxMind.MinFraud.UnitTest/WebServiceClientTest.cs
@@ -1,9 +1,7 @@
 ﻿using MaxMind.MinFraud.Exception;
 using MaxMind.MinFraud.Request;
-#if !NET461
 using Microsoft.Extensions.Options;
 using System.Collections.Generic;
-#endif
 using RichardSzalay.MockHttp;
 using System;
 using System.Net;
@@ -103,7 +101,6 @@ namespace MaxMind.MinFraud.UnitTest
             Assert.Null(exception);
         }
 
-#if !NET461
         [Fact]
         public async Task TestWebServiceClientOptionsConstructor()
         {
@@ -137,7 +134,6 @@ namespace MaxMind.MinFraud.UnitTest
 
             CompareJson(responseContent, response);
         }
-#endif
 
         private void CompareJson(string responseContent, object response)
         {

--- a/MaxMind.MinFraud/Exception/AuthenticationException.cs
+++ b/MaxMind.MinFraud/Exception/AuthenticationException.cs
@@ -38,6 +38,9 @@ namespace MaxMind.MinFraud.Exception
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")]
+#endif
         protected AuthenticationException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/MaxMind.MinFraud/Exception/HttpException.cs
+++ b/MaxMind.MinFraud/Exception/HttpException.cs
@@ -79,6 +79,9 @@ namespace MaxMind.MinFraud.Exception
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")]
+#endif
         protected HttpException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             HttpStatus = (HttpStatusCode)(info.GetValue("MaxMind.MinFraud.Exception.HttpException.HttpStatus", typeof(HttpStatusCode))
@@ -92,6 +95,9 @@ namespace MaxMind.MinFraud.Exception
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/MaxMind.MinFraud/Exception/InsufficientFundsException.cs
+++ b/MaxMind.MinFraud/Exception/InsufficientFundsException.cs
@@ -38,6 +38,9 @@ namespace MaxMind.MinFraud.Exception
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")]
+#endif
         protected InsufficientFundsException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/MaxMind.MinFraud/Exception/InvalidRequestException.cs
+++ b/MaxMind.MinFraud/Exception/InvalidRequestException.cs
@@ -68,6 +68,9 @@ namespace MaxMind.MinFraud.Exception
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")]
+#endif
         protected InvalidRequestException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             Code = info.GetString("MaxMind.MinFraud.Exception.InvalidRequestException.Code")
@@ -81,6 +84,9 @@ namespace MaxMind.MinFraud.Exception
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/MaxMind.MinFraud/Exception/MinFraudException.cs
+++ b/MaxMind.MinFraud/Exception/MinFraudException.cs
@@ -39,6 +39,9 @@ namespace MaxMind.MinFraud.Exception
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")]
+#endif
         protected MinFraudException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/MaxMind.MinFraud/Exception/PermissionRequiredException.cs
+++ b/MaxMind.MinFraud/Exception/PermissionRequiredException.cs
@@ -38,6 +38,9 @@ namespace MaxMind.MinFraud.Exception
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")]
+#endif
         protected PermissionRequiredException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/MaxMind.MinFraud/MaxMind.MinFraud.csproj
+++ b/MaxMind.MinFraud/MaxMind.MinFraud.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>API for MaxMind minFraud Score and Insights web services</Description>
     <VersionPrefix>4.1.0</VersionPrefix>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>MaxMind.MinFraud</AssemblyName>
     <AssemblyOriginatorKeyFile>../MaxMind.snk</AssemblyOriginatorKeyFile>

--- a/MaxMind.MinFraud/MaxMind.MinFraud.csproj
+++ b/MaxMind.MinFraud/MaxMind.MinFraud.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>API for MaxMind minFraud Score and Insights web services</Description>
     <VersionPrefix>4.1.0</VersionPrefix>
-    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>MaxMind.MinFraud</AssemblyName>
     <AssemblyOriginatorKeyFile>../MaxMind.snk</AssemblyOriginatorKeyFile>

--- a/MaxMind.MinFraud/WebServiceClient.cs
+++ b/MaxMind.MinFraud/WebServiceClient.cs
@@ -1,9 +1,7 @@
 ﻿#region
 
 using MaxMind.MinFraud.Exception;
-#if !NET461
 using Microsoft.Extensions.Options;
-#endif
 using MaxMind.MinFraud.Request;
 using MaxMind.MinFraud.Response;
 using MaxMind.MinFraud.Util;
@@ -39,7 +37,6 @@ namespace MaxMind.MinFraud
         private readonly List<string> _locales;
         private bool _disposed;
 
-#if !NET461
         /// <summary>
         ///     Initializes a new instance of the <see cref="WebServiceClient" /> class.
         /// </summary>
@@ -58,7 +55,7 @@ namespace MaxMind.MinFraud
             httpClient)
         {
         }
-#endif
+
         /// <summary>
         /// Constructor for minFraud web service client.
         /// </summary>

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -4,6 +4,9 @@ Release Notes
 4.2.0
 ------------------
 
+* .NET 5.0 has been removed as a target as it has reach its end of life.
+  However, if you are using .NET 5.0, the .NET Standard 2.1 target should
+  continue working for you.
 * Added `ShopifyPayments` to the `PaymentProcessor` enum.
 * Added `IWebServiceClient` to facilitate mocking of `WebServiceClient`.
   Pull request by Ian Göbl. GitHub #152.

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -7,6 +7,7 @@ Release Notes
 * .NET 5.0 has been removed as a target as it has reach its end of life.
   However, if you are using .NET 5.0, the .NET Standard 2.1 target should
   continue working for you.
+* .NET 7.0 and .NET 8.0 have been added as a target.
 * Added `ShopifyPayments` to the `PaymentProcessor` enum.
 * Added `IWebServiceClient` to facilitate mocking of `WebServiceClient`.
   Pull request by Ian Göbl. GitHub #152.


### PR DESCRIPTION
- Do not target .NET 5.0
- Add NET 8.0 and NET 7.0 targets
- Drop preprocessor checks for NET 4.61
