### PR TITLE
Add `Clear` to the `TransactionReportTag` enum (STF-190)

### DIFF
--- a/MaxMind.MinFraud.UnitTest/Request/TransactionReportTest.cs
+++ b/MaxMind.MinFraud.UnitTest/Request/TransactionReportTest.cs
@@ -84,5 +84,16 @@ namespace MaxMind.MinFraud.UnitTest.Request
                 MaxMindId = maxmindId
             });
         }
+
+        [Fact]
+        public void TestClearTag()
+        {
+            var report = new TransactionReport
+            {
+                IPAddress = IP,
+                Tag = TransactionReportTag.Clear
+            };
+            Assert.Equal(TransactionReportTag.Clear, report.Tag);
+        }
     }
 }

--- a/MaxMind.MinFraud/Request/TransactionReport.cs
+++ b/MaxMind.MinFraud/Request/TransactionReport.cs
@@ -37,6 +37,13 @@ namespace MaxMind.MinFraud.Request
         /// </summary>
         [EnumMember(Value = "chargeback")]
         Chargeback,
+
+        /// <summary>
+        /// Clear a previous transaction report tag when new information
+        /// indicates the initial classification was incorrect.
+        /// </summary>
+        [EnumMember(Value = "clear")]
+        Clear,
     }
 
     /// <summary>

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -16,6 +16,8 @@
   explicit device linking.
 - Added `Banquest`, `SummitPayments`, `Yaadpay`, and `FatZebra` to the
   `PaymentProcessor` enum.
+- Added `Clear` to the `TransactionReportTag` enum for use with the Report
+  Transaction API.
 - **BREAKING:** The minimum `MaxMind.GeoIP2` dependency has been bumped to 6.0.0
   (a transitive breaking change).
 - Custom `ToString()` overrides have been removed from all response and request


### PR DESCRIPTION
## Summary

- Adds `Clear` to the `TransactionReportTag` enum with its `[EnumMember]`
  mapping to `"clear"` and an XML doc summary.
- Adds a unit test verifying the enum value is accepted on a
  `TransactionReport`.
- Appends a bullet to the existing unreleased `6.0.0-beta1` entry in
  `releasenotes.md`.

The `clear` tag retracts a previously reported fraud report on a transaction
(restoring its label to "unknown", distinct from the positive `NotFraud`
signal). Backend support shipped in STF-15; this adds SDK support per STF-190.

Linear: https://linear.app/maxmind/issue/STF-190

## Test plan

- [x] `dotnet build MaxMind.MinFraud.sln` — clean
- [x] `dotnet run --project MaxMind.MinFraud.UnitTest ... -class "*TransactionReportTest"` — 7 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)