### PR TITLE
Deploy docs site with Hugo via GitHub Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: true
+
+      - name: Setup mise
+        uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+        with:
+          cache: true
+
+      - name: Build docs
+        env:
+          HUGO_BASEURL:
+            https://${{ github.repository_owner }}.github.io/${{
+            github.event.repository.name }}/
+        run: mise run build-docs
+
+      - name: Push rendered site to gh-pages
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/public
+          publish_branch: gh-pages
+          keep_files: true
+          user_name: "github-actions[bot]"
+          user_email: "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ Backup*/
 UpgradeLog*.XML
 
 .doxygen.conf
+
+# Hugo docs build output
+docs/.hugo_build.lock
+docs/public/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # .NET API for MaxMind minFraud Services
 
 [![NuGet](https://img.shields.io/nuget/v/MaxMind.MinFraud)](https://www.nuget.org/packages/MaxMind.MinFraud)
-[![API Docs](https://www.fuget.org/packages/MaxMind.MinFraud/badge.svg)](https://www.fuget.org/packages/MaxMind.MinFraud)
 
 ## Description
 

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -1,0 +1,13 @@
+title = "MaxMind minFraud .NET API"
+disableKinds = ["taxonomy"]
+
+[[cascade]]
+  layout = "default"
+
+[markup.highlight]
+  noClasses = true
+  style = "github"
+
+[[module.mounts]]
+  source = "../README.md"
+  target = "content/_index.md"

--- a/docs/layouts/_default/_markup/render-heading.html
+++ b/docs/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,4 @@
+<h{{ .Level }} id="{{ .Anchor }}">
+  {{- .Text | safeHTML -}}
+  <a class="heading-anchor" href="#{{ .Anchor }}" aria-label="Link to {{ .PlainText }}">#</a>
+</h{{ .Level }}>

--- a/docs/layouts/_default/default.html
+++ b/docs/layouts/_default/default.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ or .Title .File.BaseFileName }} | {{ .Site.Title }}{{ end }}</title>
+    <style>
+      :root {
+        --fg: #2d2d2d;
+        --bg: #faf9f7;
+        --accent: #1a6b50;
+        --accent-soft: rgba(26, 107, 80, 0.06);
+        --border: #d5d0c8;
+        --code-bg: #f0eeea;
+        --heading: #1a1a1a;
+        --muted: #70695f;
+      }
+
+      ::selection {
+        background: rgba(26, 107, 80, 0.15);
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: Charter, "Bitstream Charter", "Sitka Text", Cambria, serif;
+        font-size: 1.05rem;
+        line-height: 1.78;
+        color: var(--fg);
+        background: var(--bg);
+        max-width: 50rem;
+        margin: 0 auto;
+        padding: 3rem 1.5rem 5rem;
+      }
+
+      h1,
+      h2,
+      h3,
+      h4 {
+        font-family: system-ui, -apple-system, "Segoe UI", Helvetica, Arial,
+          sans-serif;
+        line-height: 1.35;
+      }
+
+      h1 {
+        font-size: 1.75rem;
+        font-weight: 800;
+        color: var(--heading);
+        margin: 0 0 1.5rem;
+        padding-bottom: 0.75rem;
+        border-bottom: 3px solid var(--accent);
+      }
+
+      h2 {
+        font-size: 1.3rem;
+        font-weight: 700;
+        color: var(--heading);
+        margin: 3rem 0 0.75rem;
+        padding-bottom: 0.4rem;
+        border-bottom: 1px solid var(--border);
+      }
+
+      h3 {
+        font-size: 1.05rem;
+        font-weight: 700;
+        color: var(--accent);
+        margin: 2.5rem 0 0.5rem;
+        padding: 0.4rem 0.75rem;
+        border-left: 3px solid var(--accent);
+        background: linear-gradient(
+          135deg,
+          var(--accent-soft),
+          transparent 80%
+        );
+        border-radius: 0 3px 3px 0;
+      }
+
+      h4 {
+        font-size: 0.92rem;
+        font-weight: 700;
+        color: var(--muted);
+        margin: 2rem 0 0.5rem;
+        padding-bottom: 0.2rem;
+        border-bottom: 1px dashed var(--border);
+      }
+
+      p {
+        margin: 0.8rem 0;
+      }
+
+      a {
+        color: var(--accent);
+        text-decoration-thickness: 1px;
+        text-underline-offset: 2px;
+        transition: text-decoration-thickness 0.15s;
+      }
+
+      a:hover {
+        text-decoration-thickness: 2px;
+      }
+
+      strong {
+        color: var(--heading);
+        font-weight: 700;
+      }
+
+      ol,
+      ul {
+        padding-left: 1.75rem;
+      }
+
+      li + li {
+        margin-top: 0.3rem;
+      }
+
+      code {
+        font-family: "JetBrains Mono", "Cascadia Code", Menlo, Consolas,
+          monospace;
+        font-size: 0.88em;
+        background: var(--code-bg);
+        padding: 0.15em 0.4em;
+        border-radius: 3px;
+        border: 1px solid rgba(0, 0, 0, 0.06);
+      }
+
+      pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 5px;
+        padding: 1rem 1.25rem;
+        overflow-x: auto;
+        line-height: 1.55;
+      }
+
+      pre code {
+        background: none;
+        padding: 0;
+        border: none;
+        font-size: 0.85em;
+      }
+
+      img {
+        max-width: 100%;
+        height: auto;
+      }
+
+      .heading-anchor {
+        opacity: 0;
+        margin-left: 0.3em;
+        font-weight: 400;
+        text-decoration: none;
+        transition: opacity 0.15s;
+      }
+
+      h1:hover .heading-anchor,
+      h2:hover .heading-anchor,
+      h3:hover .heading-anchor,
+      h4:hover .heading-anchor,
+      .heading-anchor:focus {
+        opacity: 0.4;
+      }
+
+      .heading-anchor:hover {
+        opacity: 1;
+      }
+
+      .page-nav {
+        margin-bottom: 2.5rem;
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+
+      .page-nav a {
+        font-family: system-ui, -apple-system, "Segoe UI", Helvetica, Arial,
+          sans-serif;
+        font-size: 0.85rem;
+        font-weight: 600;
+        text-decoration: none;
+        color: var(--muted);
+        padding: 0.3rem 0.75rem;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        transition: color 0.15s, border-color 0.15s, background 0.15s;
+      }
+
+      .page-nav a:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+
+      .page-nav a.active {
+        color: var(--bg);
+        background: var(--accent);
+        border-color: var(--accent);
+      }
+    </style>
+  </head>
+  <body>
+    <nav class="page-nav">
+      <a href="{{ .Site.Home.RelPermalink }}"{{ if .IsHome }} class="active" aria-current="page"{{ end }}>Overview</a>
+      <a href="{{ "doc/latest/" | relURL }}">API documentation</a>
+    </nav>
+    <main>
+      {{ .Content }}
+    </main>
+  </body>
+</html>

--- a/mise.lock
+++ b/mise.lock
@@ -51,38 +51,70 @@ checksum = "sha256:9d683d1730e302c646ccb90a23d313e7a548c8b23b5abf7d24e19ff6befe7
 url = "https://github.com/houseabsolute/precious/releases/download/v0.10.2/precious-Windows-msvc-x86_64.zip"
 url_api = "https://api.github.com/repos/houseabsolute/precious/releases/assets/345520544"
 
+[[tools.hugo]]
+version = "0.161.1"
+backend = "aqua:gohugoio/hugo"
+
+[tools.hugo."platforms.linux-arm64"]
+checksum = "sha256:382371ec3208236fb854ced51781f859b6c27a7d066b8fe90594eba14ba76d00"
+url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_0.161.1_linux-arm64.tar.gz"
+
+[tools.hugo."platforms.linux-arm64-musl"]
+checksum = "sha256:382371ec3208236fb854ced51781f859b6c27a7d066b8fe90594eba14ba76d00"
+url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_0.161.1_linux-arm64.tar.gz"
+
+[tools.hugo."platforms.linux-x64"]
+checksum = "sha256:fae28bf7909c1a42d1365b89d2e9e3d4194fbe5968ae0dd5504f562381018a1d"
+url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_0.161.1_linux-amd64.tar.gz"
+
+[tools.hugo."platforms.linux-x64-musl"]
+checksum = "sha256:fae28bf7909c1a42d1365b89d2e9e3d4194fbe5968ae0dd5504f562381018a1d"
+url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_0.161.1_linux-amd64.tar.gz"
+
+[tools.hugo."platforms.macos-arm64"]
+checksum = "sha256:b12e1cbebacf61f9cf67e0046c835142e70c829da7c16b05c1ec64a68885ee80"
+url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_0.161.1_darwin-universal.pkg"
+
+[tools.hugo."platforms.macos-x64"]
+checksum = "sha256:b12e1cbebacf61f9cf67e0046c835142e70c829da7c16b05c1ec64a68885ee80"
+url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_0.161.1_darwin-universal.pkg"
+
+[tools.hugo."platforms.windows-x64"]
+checksum = "sha256:7f8d030b37600c60bf2a782611257e6a768934fbe7724c1f3a1a501e6724cf0d"
+url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_0.161.1_windows-amd64.zip"
+
 [[tools.node]]
-version = "25.8.1"
+version = "26.1.0"
 backend = "core:node"
 
 [tools.node."platforms.linux-arm64"]
-checksum = "sha256:d990ec3c21ce8bdb6f76ed4e1c875d6e3e4b75a02d018e85df0662c0bad83b53"
-url = "https://nodejs.org/dist/v25.8.1/node-v25.8.1-linux-arm64.tar.gz"
+checksum = "sha256:fcb4c339eef70c909cae72091008a6497278e2d0fcd221c0653068cf4ea4f0c7"
+url = "https://nodejs.org/dist/v26.1.0/node-v26.1.0-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-arm64-musl"]
-checksum = "sha256:d990ec3c21ce8bdb6f76ed4e1c875d6e3e4b75a02d018e85df0662c0bad83b53"
-url = "https://nodejs.org/dist/v25.8.1/node-v25.8.1-linux-arm64.tar.gz"
+checksum = "sha256:fcb4c339eef70c909cae72091008a6497278e2d0fcd221c0653068cf4ea4f0c7"
+url = "https://nodejs.org/dist/v26.1.0/node-v26.1.0-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-x64"]
-checksum = "sha256:6fe3b8fa448579f728f7a0e5bbb3ab6a352d2c6307e13ae37a86106a3e4c9aaf"
-url = "https://nodejs.org/dist/v25.8.1/node-v25.8.1-linux-x64.tar.gz"
+checksum = "sha256:62d555c329e05e3625109f2e3a8b5195b368d5ef38266292469d32f63cd98ffd"
+url = "https://nodejs.org/dist/v26.1.0/node-v26.1.0-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-musl"]
-checksum = "sha256:6fe3b8fa448579f728f7a0e5bbb3ab6a352d2c6307e13ae37a86106a3e4c9aaf"
-url = "https://nodejs.org/dist/v25.8.1/node-v25.8.1-linux-x64.tar.gz"
+checksum = "sha256:62d555c329e05e3625109f2e3a8b5195b368d5ef38266292469d32f63cd98ffd"
+url = "https://nodejs.org/dist/v26.1.0/node-v26.1.0-linux-x64.tar.gz"
 
 [tools.node."platforms.macos-arm64"]
-checksum = "sha256:c667629236e3213616f0917b84eb52706e213c0e8a2312402335fff6fc7463c4"
-url = "https://nodejs.org/dist/v25.8.1/node-v25.8.1-darwin-arm64.tar.gz"
+checksum = "sha256:91063f665c2f5d6e69e4f8fcb66d3d476bc2785ace82267274bf4da789985ceb"
+url = "https://nodejs.org/dist/v26.1.0/node-v26.1.0-darwin-arm64.tar.gz"
 
 [tools.node."platforms.macos-x64"]
-checksum = "sha256:1e5ebf69955e01216f5c60b9c989d1bdda8e5022e2f60c75e1baf309c5bff50e"
-url = "https://nodejs.org/dist/v25.8.1/node-v25.8.1-darwin-x64.tar.gz"
+checksum = "sha256:33519b28a352de668ab0a2a64366db032a45cb629d5353f86e4576e2780f4fcf"
+url = "https://nodejs.org/dist/v26.1.0/node-v26.1.0-darwin-x64.tar.gz"
 
 [tools.node."platforms.windows-x64"]
-checksum = "sha256:09a5a0dbb2f4cefa800880012810e2dfaac0016a62e75f064c4ab7f3606b2d78"
-url = "https://nodejs.org/dist/v25.8.1/node-v25.8.1-win-x64.zip"
+checksum = "sha256:089a02c4c687451c9f0b7f1bfd252dae85a7ba27df0295a14096bdcc956fdc92"
+url = "https://nodejs.org/dist/v26.1.0/node-v26.1.0-win-x64.zip"
 
 [[tools."npm:prettier"]]
-version = "3.8.1"
+version = "3.8.3"
 backend = "npm:prettier"

--- a/mise.toml
+++ b/mise.toml
@@ -8,9 +8,18 @@ disable_backends = [
 
 [tools]
 dotnet = ["latest", "9", "8"]
+hugo = "latest"
 "github:houseabsolute/precious" = "latest"
 node = "latest"
 "npm:prettier" = "latest"
+
+[tasks.build-docs]
+description = "Build the docs site with Hugo"
+run = "hugo --source docs --minify"
+
+[tasks.serve-docs]
+description = "Serve the docs site locally with Hugo dev server"
+run = "hugo server --source docs"
 
 [hooks]
 enter = "mise install --quiet --locked"


### PR DESCRIPTION
## Summary

Migrates the Pages index from Jekyll on `gh-pages` to a Hugo build that
publishes back onto `gh-pages` from GitHub Actions. All CSS is now
inlined in the layout template — no external CDN dependencies.

The historical Doxygen output under `/doc/vX.Y.Z/` (frozen since 2022)
is preserved untouched by the workflow's `keep_files: true`, matching
the Terraform comment that calls out the intent of keeping old API doc
links alive.

- Hugo site lives under `docs/` on `main` and mounts `README.md` as
  the home page
- A small pill nav links from the overview to the Doxygen output at
  `/doc/latest/`
- `.github/workflows/pages.yml` builds with `mise run build-docs` and
  pushes to `gh-pages` via `peaceiris/actions-gh-pages` with
  `keep_files: true`
- No `release.sh` change needed — this repo's release script doesn't
  publish to gh-pages

Same design as MaxMind-DB PR #221.

For STF-448.

## Post-merge steps

1. Verify the live site at https://maxmind.github.io/minfraud-api-dotnet/
   and a sample `/doc/latest/` still loads after the next workflow run
2. In a separate commit on `gh-pages`, drop the legacy Jekyll source
   files

Pages source stays on `gh-pages` — no Terraform change for this repo.

## Test plan

- [x] `mise run build-docs` succeeds with no warnings
- [x] Rendered `<title>`, `<h1>`, and pill nav are correct
- [x] No `static-gh.maxmind.com` references in the new site
- [ ] Build job passes in CI (push step only runs on `main`)
- [ ] After merge, confirm the workflow pushes successfully to gh-pages
      and `/doc/vX.Y.Z/` subtrees are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)