### PR TITLE
Mark ReportAsync validation as a breaking change in release notes

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -23,10 +23,11 @@
   `PaymentProcessor` enum.
 - Added `Clear` to the `TransactionReportTag` enum for use with the Report
   Transaction API.
-- `ReportAsync` on `MaxMind.MinFraud.WebServiceClient` now validates that the
-  `TransactionReport` includes at least one of `IPAddress`, `MinFraudId`,
-  `MaxMindId`, or `TransactionId`, throwing `ArgumentException` if none are set.
-  Previously this check only ran in the (now obsolete) constructor.
+- **BREAKING:** `ReportAsync` on `MaxMind.MinFraud.WebServiceClient` now
+  validates that the `TransactionReport` includes at least one of `IPAddress`,
+  `MinFraudId`, `MaxMindId`, or `TransactionId`, throwing `ArgumentException` if
+  none are set. Previously this check only ran in the (now obsolete)
+  constructor.
 - A `Guid.Empty` value assigned to the `MinFraudId` property on
   `MaxMind.MinFraud.Request.TransactionReport` is now normalized to `null`,
   matching the behavior of the obsolete constructor.


### PR DESCRIPTION
Per review feedback, the new ArgumentException thrown by ReportAsync
when the TransactionReport lacks any identifier is a behavior change
on the object-initializer code path and should be flagged as
BREAKING for consistency with the other breaking entries.

This is a release-notes-only change on top of the tagged v6.0.0
commit; the published GitHub Release body and the v6.0.0 NuGet
package are unaffected.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
