### PR TITLE
Use 'GeoIP'/'GeoLite' branding in documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ code in this repository.
 minFraud fraud detection web services:
 
 - **minFraud Score**: Risk score for transactions
-- **minFraud Insights**: Score plus GeoIP2 data and device/email intelligence
+- **minFraud Insights**: Score plus GeoIP data and device/email intelligence
 - **minFraud Factors**: All Insights data plus risk reasons and deprecated
   subscores
 - **Transaction Reporting API**: Report chargebacks and fraud to improve
@@ -121,7 +121,7 @@ var transaction = new Transaction {
 Score (base)
   ├─ Properties: RiskScore, Id, Disposition, Warnings, FundsRemaining, IPAddress
   └─ Insights (extends Score)
-      ├─ Overrides IPAddress with full GeoIP2 data
+      ├─ Overrides IPAddress with full GeoIP data
       ├─ Adds: CreditCard, Device, Email, BillingAddress, ShippingAddress, Phones
       └─ Factors (extends Insights)
           └─ Adds: RiskScoreReasons, Subscores (obsolete as of 2025-03)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ minFraud fraud detection web services:
   minFraud accuracy
 
 The library provides both synchronous and asynchronous methods, supports ASP.NET
-Core dependency injection, and integrates deeply with MaxMind's GeoIP2 library
+Core dependency injection, and integrates deeply with MaxMind's GeoIP library
 for IP intelligence.
 
 **Key Technologies:**
@@ -79,7 +79,7 @@ MaxMind.MinFraud/
 │   └── CustomInputs.cs        # Builder pattern for custom fields
 ├── Response/           # Response models (Score, Insights, Factors)
 │   ├── Score.cs               # Base response (RiskScore, Id, Warnings)
-│   ├── Insights.cs            # Extends Score, adds GeoIP2 & device data
+│   ├── Insights.cs            # Extends Score, adds GeoIP & device data
 │   ├── Factors.cs             # Extends Insights, adds RiskScoreReasons
 │   └── IPAddress.cs, Device.cs, Email.cs, etc.
 ├── Util/               # JSON converters and helpers
@@ -132,13 +132,13 @@ Score (base)
 - Each level adds more detail without breaking compatibility
 - Interface-based polymorphism for `IIPAddress` (Score uses minimal, Insights
   uses full)
-- Response models inherit from GeoIP2 models (e.g.,
+- Response models inherit from GeoIP models (e.g.,
   `IPAddress : InsightsResponse`)
 - All response properties are init-only with default empty objects (never null)
 
-#### 3. **GeoIP2 Integration via Inheritance**
+#### 3. **GeoIP Integration via Inheritance**
 
-minFraud response models inherit from and extend GeoIP2 models:
+minFraud response models inherit from and extend GeoIP models:
 
 ```csharp
 public sealed class IPAddress : InsightsResponse, IIPAddress
@@ -152,9 +152,9 @@ public sealed class IPAddress : InsightsResponse, IIPAddress
 
 **Implications:**
 
-- Changes to GeoIP2 models affect minFraud responses
-- When adding fields, check if they belong in GeoIP2 or minFraud layer
-- Use GeoIP2 patterns for location-related data
+- Changes to GeoIP models affect minFraud responses
+- When adding fields, check if they belong in GeoIP or minFraud layer
+- Use GeoIP patterns for location-related data
 
 #### 4. **Email Address Normalization**
 
@@ -298,8 +298,8 @@ back to JSON and match the original structure.
 
 ### Adding New Fields to Existing Response Models
 
-1. **Determine if field is GeoIP2 or minFraud-specific**
-   - GeoIP2: Location data, ISP, traits, etc. → Add to GeoIP2 library first
+1. **Determine if field is GeoIP or minFraud-specific**
+   - GeoIP: Location data, ISP, traits, etc. → Add to GeoIP library first
    - minFraud: Risk, device intelligence, email intelligence → Add here
 
 2. **Add property** with init-only setter:
@@ -509,12 +509,12 @@ Requires `EnumMemberValueConverter<T>` in JSON options.
 - Provides base models for response classes (InsightsResponse, Location, Traits,
   etc.)
 - minFraud responses inherit from and extend these models
-- Changes to GeoIP2 models can affect minFraud API surface
+- Changes to GeoIP models can affect minFraud API surface
 
 **System.Text.Json**
 
 - Modern JSON serialization (not Newtonsoft.Json)
-- Requires custom converters for enums, IP addresses, GeoIP2 types
+- Requires custom converters for enums, IP addresses, GeoIP types
 - Uses snake_case naming via `[JsonPropertyName]` attributes
 
 **Microsoft.Extensions.Options**

--- a/MaxMind.MinFraud/Response/GeoIP2Location.cs
+++ b/MaxMind.MinFraud/Response/GeoIP2Location.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 namespace MaxMind.MinFraud.Response
 {
     /// <summary>
-    /// A subclass of the GeoIP2 Location model with minFraud-specific
+    /// A subclass of the GeoIP Location model with minFraud-specific
     /// additions.
     /// </summary>
     public sealed record GeoIP2Location : Location

--- a/MaxMind.MinFraud/Response/IPAddress.cs
+++ b/MaxMind.MinFraud/Response/IPAddress.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 namespace MaxMind.MinFraud.Response
 {
     /// <summary>
-    /// Model for minFraud GeoIP2 Insights data.
+    /// Model for minFraud GeoIP Insights data.
     /// </summary>
     public sealed record IPAddress : InsightsResponse, IIPAddress
     {

--- a/MaxMind.MinFraud/Response/Insights.cs
+++ b/MaxMind.MinFraud/Response/Insights.cs
@@ -8,7 +8,7 @@ namespace MaxMind.MinFraud.Response
     public record Insights : Score
     {
         /// <summary>
-        /// An object containing GeoIP2 and minFraud Insights information about
+        /// An object containing GeoIP and minFraud Insights information about
         /// the IP address.
         /// </summary>
         [JsonPropertyName("ip_address")]

--- a/MaxMind.MinFraud/WebServiceClient.cs
+++ b/MaxMind.MinFraud/WebServiceClient.cs
@@ -129,7 +129,7 @@ namespace MaxMind.MinFraud
                 throw new MinFraudException(
                     $"WithLocales returned {withLocales.GetType().FullName} instead of "
                     + $"the expected {typeof(Response.IPAddress).FullName}. "
-                    + "This may indicate an incompatible GeoIP2 library version.");
+                    + "This may indicate an incompatible GeoIP library version.");
             }
             return factors with { IPAddress = ipAddress };
         }
@@ -151,7 +151,7 @@ namespace MaxMind.MinFraud
                 throw new MinFraudException(
                     $"WithLocales returned {withLocales.GetType().FullName} instead of "
                     + $"the expected {typeof(Response.IPAddress).FullName}. "
-                    + "This may indicate an incompatible GeoIP2 library version.");
+                    + "This may indicate an incompatible GeoIP library version.");
             }
             return insights with { IPAddress = ipAddress };
         }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The legacy minFraud Standard and Premium services are not supported by this API.
 This library works with .NET Framework version 4.6.1 and above and .NET Standard
 2.0 or above.
 
-This library depends on [GeoIP2](https://www.nuget.org/packages/MaxMind.GeoIP2/)
+This library depends on [GeoIP](https://www.nuget.org/packages/MaxMind.GeoIP2/)
 and its dependencies.
 
 ## Installation


### PR DESCRIPTION
Updates prose/documentation to refer to the products as "GeoIP"/"GeoLite" instead of "GeoIP2"/"GeoLite2". Technical identifiers (packages, class names, .mmdb filenames, edition IDs, the geolite.info hostname, URLs) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)