### PR TITLE
Enable NuGet package validation

### DIFF
--- a/MaxMind.MinFraud/MaxMind.MinFraud.csproj
+++ b/MaxMind.MinFraud/MaxMind.MinFraud.csproj
@@ -15,6 +15,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/maxmind/minfraud-api-dotnet</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <EnablePackageValidation>true</EnablePackageValidation>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/MaxMind.MinFraud/MaxMind.MinFraud.csproj
+++ b/MaxMind.MinFraud/MaxMind.MinFraud.csproj
@@ -16,6 +16,7 @@
     <PackageProjectUrl>https://github.com/maxmind/minfraud-api-dotnet</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>6.1.0</PackageValidationBaselineVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -105,3 +105,12 @@ git commit -m "Prepare for $version" -a
 git push
 
 gh release create --target "$(git branch --show-current)" -t "$version" -n "$notes" "$tag"
+
+# Now that the release is tagged, validate future changes against it. The
+# package may not be downloadable from NuGet until several minutes after
+# the release workflow publishes it.
+sed -i "s|<PackageValidationBaselineVersion>[^<]*</PackageValidationBaselineVersion>|<PackageValidationBaselineVersion>$version</PackageValidationBaselineVersion>|" MaxMind.MinFraud/MaxMind.MinFraud.csproj
+
+git commit -m "Set package validation baseline to $version" -a
+
+git push


### PR DESCRIPTION
## What

Enable NuGet package validation for `MaxMind.MinFraud` by adding `<EnablePackageValidation>true</EnablePackageValidation>` to the project, matching what `MaxMind.GeoIP2` and `MaxMind.Db` already do.

## Why

With this enabled, `dotnet pack` runs `Microsoft.DotNet.PackageValidation`, which fails the build if the package's public API is binary- or source-incompatible with the latest published release. This catches accidental breaking API changes at pack time (the release workflow already runs `dotnet pack` on every pull request), keeping the library consistent with the validation the other MaxMind .NET packages already have.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled NuGet package validation in the project to strengthen release quality checks.
  * Added automated updating of the package validation baseline to the newly released version during the release process, ensuring validation stays aligned with each release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->