### PR TITLE
Add residential proxy data to Anonymizer

### DIFF
--- a/MaxMind.MinFraud.UnitTest/Response/InsightsTest.cs
+++ b/MaxMind.MinFraud.UnitTest/Response/InsightsTest.cs
@@ -70,7 +70,12 @@ namespace MaxMind.MinFraud.UnitTest.Response
                             "is_residential_proxy": true,
                             "is_tor_exit_node": false,
                             "network_last_seen": "2025-01-15",
-                            "provider_name": "TestVPN"
+                            "provider_name": "TestVPN",
+                            "residential": {
+                                "confidence": 82,
+                                "network_last_seen": "2026-05-11",
+                                "provider_name": "quickshift"
+                            }
                         }
                     },
                     "risk_score": 0.5
@@ -89,6 +94,56 @@ namespace MaxMind.MinFraud.UnitTest.Response
             Assert.Equal("2025-01-15", anonymizer.NetworkLastSeen?.ToString("yyyy-MM-dd"));
 #endif
             Assert.Equal("TestVPN", anonymizer.ProviderName);
+
+            Assert.Equal(82, anonymizer.Residential?.Confidence);
+#if NET6_0_OR_GREATER
+            Assert.Equal("2026-05-11", anonymizer.Residential?.NetworkLastSeen?.ToString("yyyy-MM-dd"));
+#endif
+            Assert.Equal("quickshift", anonymizer.Residential?.ProviderName);
+        }
+
+        [Fact]
+        public void TestIPAddressAnonymizerResidentialOnly()
+        {
+            // The anonymizer object may contain only the residential
+            // sub-object, e.g. when a network has residential proxy data
+            // but no other anonymizer data.
+            var insights = JsonSerializer.Deserialize<Insights>(
+                """
+                {
+                    "id": "b643d445-18b2-4b9d-bad4-c9c4366e402a",
+                    "ip_address": {
+                        "country": {"iso_code": "US"},
+                        "anonymizer": {
+                            "residential": {
+                                "confidence": 82,
+                                "network_last_seen": "2026-05-11",
+                                "provider_name": "quickshift"
+                            }
+                        }
+                    },
+                    "risk_score": 0.5
+                }
+                """)!;
+
+            var anonymizer = insights.IPAddress.Anonymizer;
+            Assert.Null(anonymizer.Confidence);
+            Assert.False(anonymizer.IsAnonymous);
+            Assert.False(anonymizer.IsAnonymousVpn);
+            Assert.False(anonymizer.IsHostingProvider);
+            Assert.False(anonymizer.IsPublicProxy);
+            Assert.False(anonymizer.IsResidentialProxy);
+            Assert.False(anonymizer.IsTorExitNode);
+#if NET6_0_OR_GREATER
+            Assert.Null(anonymizer.NetworkLastSeen);
+#endif
+            Assert.Null(anonymizer.ProviderName);
+
+            Assert.Equal(82, anonymizer.Residential?.Confidence);
+#if NET6_0_OR_GREATER
+            Assert.Equal("2026-05-11", anonymizer.Residential?.NetworkLastSeen?.ToString("yyyy-MM-dd"));
+#endif
+            Assert.Equal("quickshift", anonymizer.Residential?.ProviderName);
         }
 
         [Fact]

--- a/MaxMind.MinFraud.UnitTest/TestData/factors-response.json
+++ b/MaxMind.MinFraud.UnitTest/TestData/factors-response.json
@@ -148,7 +148,12 @@
       "is_public_proxy": true,
       "is_residential_proxy": true,
       "is_tor_exit_node": true,
-      "provider_name": "TestVPN"
+      "provider_name": "TestVPN",
+      "residential": {
+        "confidence": 82,
+        "network_last_seen": "2026-05-11",
+        "provider_name": "quickshift"
+      }
     }
   },
   "billing_address": {

--- a/MaxMind.MinFraud.UnitTest/TestData/insights-response.json
+++ b/MaxMind.MinFraud.UnitTest/TestData/insights-response.json
@@ -148,7 +148,12 @@
       "is_public_proxy": true,
       "is_residential_proxy": true,
       "is_tor_exit_node": true,
-      "provider_name": "TestVPN"
+      "provider_name": "TestVPN",
+      "residential": {
+        "confidence": 82,
+        "network_last_seen": "2026-05-11",
+        "provider_name": "quickshift"
+      }
     }
   },
   "billing_address": {

--- a/MaxMind.MinFraud.UnitTest/WebServiceClientTest.cs
+++ b/MaxMind.MinFraud.UnitTest/WebServiceClientTest.cs
@@ -57,6 +57,12 @@ namespace MaxMind.MinFraud.UnitTest
 
             Assert.Equal("310", response.IPAddress.Traits.MobileCountryCode);
             Assert.Equal("004", response.IPAddress.Traits.MobileNetworkCode);
+
+            Assert.Equal(82, response.IPAddress.Anonymizer.Residential?.Confidence);
+#if NET6_0_OR_GREATER
+            Assert.Equal(new DateOnly(2026, 5, 11), response.IPAddress.Anonymizer.Residential?.NetworkLastSeen);
+#endif
+            Assert.Equal("quickshift", response.IPAddress.Anonymizer.Residential?.ProviderName);
         }
 
         [Fact]

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 6.1.0 (TBD)
+
+- The `Anonymizer` property on `MaxMind.MinFraud.Response.IPAddress` (inherited
+  from `MaxMind.GeoIP2.Model.Anonymizer`) now includes a `Residential` property.
+  This is of the new `MaxMind.GeoIP2.Model.AnonymizerFeed` type and contains
+  residential proxy data for the network: `Confidence`, `NetworkLastSeen`
+  (`DateOnly` on .NET 6.0+), and `ProviderName`. `Anonymizer.Residential` may be
+  populated even when none of the other `Anonymizer` properties are set. This
+  requires `MaxMind.GeoIP2` 6.1.0 or greater.
+
 ## 6.0.0 (2026-05-22)
 
 - **BREAKING:** All response classes in `MaxMind.MinFraud.Response` have been


### PR DESCRIPTION
## Summary

Surfaces the new `residential` sub-object of the `anonymizer` object in the minFraud Insights and Factors `ip_address` response. The models reuse the GeoIP2 library's Anonymizer record, so this is a fixtures/tests/changelog change; the field flows through via the dependency.

Depends on maxmind/GeoIP2-dotnet#494. At release time the `MaxMind.GeoIP2` PackageReference must be bumped to 6.1.0 once published.

## Testing

With GeoIP2 packed from that PR (local NuGet source, not committed): dotnet build clean on all five target frameworks; 181/181 tests pass on net8.0/net9.0/net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)