### PR TITLE
Validate package API against the latest release

### DIFF
--- a/MaxMind.MinFraud/MaxMind.MinFraud.csproj
+++ b/MaxMind.MinFraud/MaxMind.MinFraud.csproj
@@ -16,6 +16,7 @@
     <PackageProjectUrl>https://github.com/maxmind/minfraud-api-dotnet</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>6.1.0</PackageValidationBaselineVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -105,3 +105,12 @@ git commit -m "Prepare for $version" -a
 git push
 
 gh release create --target "$(git branch --show-current)" -t "$version" -n "$notes" "$tag"
+
+# Now that the release is tagged, validate future changes against it. The
+# package may not be downloadable from NuGet until several minutes after
+# the release workflow publishes it.
+sed -i "s|<PackageValidationBaselineVersion>[^<]*</PackageValidationBaselineVersion>|<PackageValidationBaselineVersion>$version</PackageValidationBaselineVersion>|" MaxMind.MinFraud/MaxMind.MinFraud.csproj
+
+git commit -m "Set package validation baseline to $version" -a
+
+git push


### PR DESCRIPTION
## What

Set `PackageValidationBaselineVersion` to 6.1.0 (the latest published release) in `MaxMind.MinFraud.csproj`, and update `dev-bin/release.sh` to bump the baseline to the new version right after tagging a release.

## Why

`EnablePackageValidation` on its own (#429) only runs the compatible-TFM validators; it does not compare the package against the previously published release, so an accidental breaking API change still packs successfully. With `PackageValidationBaselineVersion` set, `dotnet pack` downloads the baseline package from NuGet and fails on binary- or source-incompatible changes. Since the release workflow runs `dotnet pack` on every pull request, accidental breaking changes are caught in CI (STF-55).

The baseline is bumped *after* tagging so that pull requests are always validated against the latest published release, while the tagged commit itself is validated against the release it replaces (the new version is not yet on NuGet when the release build packs). One caveat: packs that run in the few minutes between tagging and the package becoming downloadable from NuGet can fail transiently; a re-run fixes them.

This is the follow-up discussed in #429: MaxMind.MinFraud 6.1.0 has since been published, so there is now a real baseline to validate against.

Verified locally: making `Warning.Code` internal fails `dotnet pack` with `CP0002` against the 6.1.0 baseline for every TFM, and the unmodified branch packs cleanly. Intentional breaking changes (e.g., for a future major release) can be recorded with `dotnet pack /p:ApiCompatGenerateSuppressionFile=true`.

This PR is stacked on #429 (base branch `enable-package-validation`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)