### PR TITLE
Expand email alias domain lists

### DIFF
--- a/MaxMind.MinFraud.UnitTest/Request/EmailTest.cs
+++ b/MaxMind.MinFraud.UnitTest/Request/EmailTest.cs
@@ -150,9 +150,17 @@ namespace MaxMind.MinFraud.UnitTest.Request
             Assert.Equal("2dc11f44b436d1bc4ecfd4806e469d33", e.AddressMD5);
             Assert.Equal("user.fastmail.com", e.Domain);
 
+            e = new Email { Address = "alias@user.fastmail.ca", HashAddress = true };
+            Assert.Equal("49ed983cae54ad883760e852fc22e4f7", e.AddressMD5);
+            Assert.Equal("user.fastmail.ca", e.Domain);
+
             e = new Email { Address = "foo-bar@ymail.com", HashAddress = true };
             Assert.Equal("fead35da88f8414ec0414ef5f25d49c8", e.AddressMD5);
             Assert.Equal("ymail.com", e.Domain);
+
+            e = new Email { Address = "test-alias@myyahoo.com", HashAddress = true };
+            Assert.Equal("bc25e04daa7e10e5027fb5c4f9b6c89a", e.AddressMD5);
+            Assert.Equal("myyahoo.com", e.Domain);
 
             e = new Email { Address = "foo@example.com.com", HashAddress = true };
             Assert.Equal("b48def645758b95537d4424c84d1a9ff", e.AddressMD5);

--- a/MaxMind.MinFraud/Request/Email.cs
+++ b/MaxMind.MinFraud/Request/Email.cs
@@ -130,6 +130,7 @@ namespace MaxMind.MinFraud.Request
             "fastemailer.com",
             "fastest.cc",
             "fastimap.com",
+            "fastmail.ca",
             "fastmail.cn",
             "fastmail.co.uk",
             "fastmail.com",
@@ -224,6 +225,7 @@ namespace MaxMind.MinFraud.Request
 
         private static readonly HashSet<string> _yahooDomains =
         [
+            "myyahoo.com",
             "y7mail.com",
             "yahoo.at",
             "yahoo.be",


### PR DESCRIPTION
## Summary

Adds two newly identified alias domains so more equivalent addresses
normalize to the same value before hashing:

- `fastmail.ca` — Fastmail's own Canadian domain. Confirmed via MX
  records resolving to Fastmail's `messagingengine.com` infrastructure,
  and listed on Fastmail's official domain list.
- `myyahoo.com` — an alternate Yahoo-owned signup domain (WHOIS
  registrant: Yahoo Assets LLC), functionally identical to yahoo.com.

Both run on their provider's own native mail platform with no
third-party migration history, so the existing normalization logic
applies to them exactly as it does to their canonical counterparts.

This mirrors the same addition made to the minFraud web service's own
email normalization.

## Testing

Added matching unit test cases following the existing pattern. Not run
locally — no .NET SDK available in this environment — so CI should be
checked before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email address normalization for Fastmail and Yahoo domains.
  * Added support for `fastmail.ca` and `myyahoo.com` domain handling.
  * Updated normalization coverage for additional email address formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->